### PR TITLE
Fix: use the slim docker python image for faster builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Container image that runs your code
 #FROM alpine:3.10
-FROM python
+FROM python:slim
 
 # Install checkov
 RUN pip install -U bridgecrew


### PR DESCRIPTION
thanks for this awesome action!

just a proposal for using the slim image since the build was noticeably rather slower