### PR TITLE
Make documentation correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ All you need to do is:
 2. Set up an environment variable with your Bridgecrew API key, which you can get from your [Bridgecrew account](https://www.bridgecrew.cloud/integrations).
 3. In the app build job, uses the `bridgecrewio/bridgecrew-action@master`
 4. Optionally, supply parameters to customize GitHub action behaviour
+
 ## Usage Examples
 
 ### Scan IaC in your repository
@@ -30,7 +31,8 @@ All you need to do is:
 ```
 
 ### Github code scanning
-Bridgecrew supports github [code scanning](https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/about-code-scanning). 
+
+Bridgecrew supports github [code scanning](https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/about-code-scanning).
 An example workflow configuration can be found [here](examples/code_scanning.yml).
 
 ## GitHub action Parameters
@@ -39,15 +41,16 @@ An example workflow configuration can be found [here](examples/code_scanning.yml
 | -----------| -------------------------------------------------------------------------------------------------------- | ------------- | ------------- | ------------- |
 | api-key | Environment variable name of the Bridgecrew API key from Bridgecrew app | No |  | Secret parameter |
 | directory | IaC root directory to scan | No | "." | Input parameter |
-| soft-fail | Runs checks without failing build | No | | Input parameters |
+| soft_fail | Runs checks without failing build | No | | Input parameters |
 | check | filter scan to run only on a specific check identifier, You can specify multiple checks separated by comma delimiter | No |  | Input parameters |
-| skip-check | filter scan to run on all check but a specific check identifier(blacklist), You can specify multiple checks separated by comma delimiter | No |  | Input parameters |
+| skip_check | filter scan to run on all check but a specific check identifier(blacklist), You can specify multiple checks separated by comma delimiter | No |  | Input parameters |
 | quiet | display only failed checks | No |  | Input parameters |
-| external-checks-dir | Directory for custom checks to be loaded | No |  | Input parameters |
+| external_checks_dir | Directory for custom checks to be loaded | No |  | Input parameters |
 
 Full reference docs [here](https://docs.bridgecrew.io/docs/integrate-with-github-actions-v2).
 
 ## Screenshots
+
 Reject pull requests containing infrastructure code configuration errors
 ![](resources/failed-action.png)
 Find & fix resources that might be a risk

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The community plan does not limit the number of scans or users you can invite to
 In fact, it is very easy to start using the GitHub action.
 All you need to do is:
 
-1. Follow the instructions at [GitHub configuration a workflow](https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow) to enable Github Action in your repository. 
+1. Follow the instructions at [GitHub configuration a workflow](https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow) to enable Github Action in your repository.
 2. Set up an environment variable with your Bridgecrew API key, which you can get from your [Bridgecrew account](https://www.bridgecrew.cloud/integrations).
 3. In the app build job, uses the `bridgecrewio/bridgecrew-action@master`
 4. Optionally, supply parameters to customize GitHub action behaviour
@@ -23,11 +23,17 @@ All you need to do is:
 ### Scan IaC in your repository
 
 ```yaml
-  - name: Run Bridgecrew 
-    id: Bridgecrew
-    uses: bridgecrewio/bridgecrew-action@master
-    with:
-      api-key: ${{ secrets.API_KEY }}
+      - name: Run Bridgecrew 
+        id: Bridgecrew
+        uses: bridgecrewio/bridgecrew-action@master
+        with:
+         api-key: ${{ secrets.BRIDGECREW_API_KEY }}
+         directory: "example/examplea"
+         soft_fail: false
+         skip_check: CKV_GCP_23
+         output_format: cli
+         quiet: false
+         external_checks_dir: ./checkov
 ```
 
 ### Github code scanning
@@ -43,9 +49,10 @@ An example workflow configuration can be found [here](examples/code_scanning.yml
 | directory | IaC root directory to scan | No | "." | Input parameter |
 | soft_fail | Runs checks without failing build | No | | Input parameters |
 | check | filter scan to run only on a specific check identifier, You can specify multiple checks separated by comma delimiter | No |  | Input parameters |
-| skip_check | filter scan to run on all check but a specific check identifier(blacklist), You can specify multiple checks separated by comma delimiter | No |  | Input parameters |
+| skip_check | filter scan to run on all check but a specific check identifier(blacklist), You can specify multiple checks separated by comma delimiter, clashes with check | No |  | Input parameters |
 | quiet | display only failed checks | No |  | Input parameters |
 | external_checks_dir | Directory for custom checks to be loaded | No |  | Input parameters |
+| output_format| The format of the output - json - cli - sarif | No |  | Input parameters |
 
 Full reference docs [here](https://docs.bridgecrew.io/docs/integrate-with-github-actions-v2).
 


### PR DESCRIPTION
If you follow the current docs, the params fail:
https://github.com/JamesWoolfenden/terraform-aws-test-gha/actions/runs/548116129

If you correct to the actual params:
https://github.com/JamesWoolfenden/terraform-aws-test-gha/blob/main/.github/workflows/main.yml

e.g.
      - name: Run Bridgecrew 
        id: Bridgecrew
        uses: bridgecrewio/bridgecrew-action@master
        with:
         api-key: ${{ secrets.BRIDGECREW_API_KEY }}
         directory: "example/examplea"
         soft_fail: false
         skip_check: CKV_GCP_23
         output_format: cli
         quiet: false
         external_checks_dir: ./checkov