### PR TITLE
Fix soft-fail to soft_fail in examples

### DIFF
--- a/examples/code_scanning.yml
+++ b/examples/code_scanning.yml
@@ -22,7 +22,7 @@ jobs:
       uses: bridgecrewio/bridgecrew-action@master
       with:
         api-key: ${{ secrets.API_KEY }}
-        soft-fail: true
+        soft_fail: true
       env:  
         GITHUB_REPOSITORY: ${{ github.repository }}
         GITHUB_REF: ${{ github.ref }}

--- a/examples/vulnerability_scan_job.yml
+++ b/examples/vulnerability_scan_job.yml
@@ -20,7 +20,7 @@ jobs:
         uses: bridgecrewio/bridgecrew-action@master
         with:
           directory: "terraform"
-          soft-fail: true
+          soft_fail: true
 
       - name: Scan IaC file
         id: Bridgecrew-file-scanner


### PR DESCRIPTION
This PR addresses an issue in the Bridgecrew action examples. `soft-fail` has been changed to `soft_fail` in the examples.