### PR TITLE
fix(action): create missing log_level & download_external_modules parameters on Docker call

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,6 @@ inputs:
     description: 'bridgecrew configuration file'
     required: false
 
-
 branding:
   icon: 'shield'
   color: 'purple'
@@ -54,6 +53,8 @@ runs:
     - ${{ inputs.soft_fail }}
     - ${{ inputs.external_checks_dir }}
     - ${{ inputs.output_format }}
+    - ${{ inputs.log_level }}
+    - ${{ inputs.download_external_modules }}
     - ${{ inputs.config_file }}
 
   env:


### PR DESCRIPTION
Fixes #18
https://github.com/bridgecrewio/bridgecrew-action/pull/19