### PR TITLE
get bridgecrew version from pypi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,13 @@ jobs:
         run: |
           # update bridgecrew version
           version=$(curl -s https://pypi.org/pypi/bridgecrew/json  | jq -r '.info.version')
+          url='https://registry.hub.docker.com/v2/repositories/bridgecrew/bridgecrew/tags/'
+          url+=$version
+          exists=$(curl -s -I -o /dev/null -w "%{http_code}" $url)
+          if [[ $exists -ne 200 ]]; then
+            echo "Docker image not found"
+            exit 1
+          fi
           sed -i'.bkp' -e 's/docker:\/\/bridgecrew\/bridgecrew.*'\''/docker:\/\/bridgecrew\/bridgecrew:'"${version}"''\''/g' action.yml
           rm action.yml.bkp
       - uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - name: update release
         run: |
           # update bridgecrew version
-          version=$(curl -s https://api.github.com/repos/bridgecrewio/checkov/releases/latest | jq -r '.name')
+          version=$(curl -s https://pypi.org/pypi/bridgecrew/json  | jq -r '.info.version')
           sed -i'.bkp' -e 's/docker:\/\/bridgecrew\/bridgecrew.*'\''/docker:\/\/bridgecrew\/bridgecrew:'"${version}"''\''/g' action.yml
           rm action.yml.bkp
       - uses: stefanzweifel/git-auto-commit-action@v4

--- a/action.yml
+++ b/action.yml
@@ -70,7 +70,7 @@ branding:
 
 runs:
   using: 'docker'
-  image: 'docker://bridgecrew/bridgecrew:2.2.21'
+  image: 'docker://bridgecrew/bridgecrew:2.2.22'
   args:
     - ${{ inputs.directory }}
     - ${{ inputs.check }}


### PR DESCRIPTION
This PR fixes the version retrieval for bridgecrew action to be from bridgecrew-py instead of checkov.
